### PR TITLE
Replace optparse with argparse

### DIFF
--- a/all_locations.py
+++ b/all_locations.py
@@ -50,11 +50,11 @@ def main(source, dump_modules, dump_workspaces):
         )
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-s", "--source")
-    p.add_option("-m", "--modules", default=False, action="store_true")
-    p.add_option("-w", "--workspaces", default=False, action="store_true")
-    opt, args = p.parse_args()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--source", required=True)
+    parser.add_argument("-m", "--modules", action="store_true", default=False)
+    parser.add_argument("-w", "--workspaces", action="store_true", default=False)
+    args = parser.parse_args()
 
-    main(opt.source, opt.modules, opt.workspaces)
+    main(args.source, args.modules, args.workspaces)

--- a/check_latest.py
+++ b/check_latest.py
@@ -3,6 +3,7 @@ import json
 from collections import defaultdict
 import os
 import sys
+import argparse
 
 from tfe_tools.common import get_latest_versions, sanitize_path, tfe_token, get_requests_session, mod_dependencies
 
@@ -34,14 +35,13 @@ def main(terraform_base, terraform_url):
     return module_keys
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-t", default="https://terraform.example.com", dest="terraform_base")
-    p.add_option("-u", default="terraform.example.com", dest="terraform_url")
-    opt, arg = p.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", default="https://terraform.example.com", dest="terraform_base")
+    parser.add_argument("-u", default="terraform.example.com", dest="terraform_url")
+    args = parser.parse_args()
     print(
         json.dumps(
-            main(opt.terraform_base, opt.terraform_url),
+            main(args.terraform_base, args.terraform_url),
             separators=(',', ':'),
             indent=4,
             sort_keys=True

--- a/checks/vault_access.py
+++ b/checks/vault_access.py
@@ -27,14 +27,14 @@ def main(output):
         )
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("--output", default=os.path.join(
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default=os.path.join(
         os.path.join(
             os.path.dirname(__file__),
             os.path.pardir
         ), 
         "reports/vault_access.json"
     ))
-    opt, arg = p.parse_args()
-    main(opt.output)
+    args = parser.parse_args()
+    main(args.output)

--- a/envcmp.py
+++ b/envcmp.py
@@ -56,10 +56,9 @@ def main(cmp_a, cmp_b):
         )
     )
 if __name__ == '__main__':
-    from optparse import OptionParser
-    parser = OptionParser()
-    opt, args = parser.parse_args()
-    if len(args) != 2:
-        sys.stderr.write("Must specific two environments!\n")
-        sys.exit(1)
-    main(args[0], args[1])
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cmp_a", help="First environment to compare")
+    parser.add_argument("cmp_b", help="Second environment to compare")
+    args = parser.parse_args()
+    main(args.cmp_a, args.cmp_b)

--- a/find_rsc_attrs_in_workspaces.py
+++ b/find_rsc_attrs_in_workspaces.py
@@ -34,15 +34,15 @@ def main(terraform_org, terraform_url, resource_type, attrs, base_dir="./reports
     return statefiles
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("--org", dest="terraform_org", default="clover")
-    p.add_option("--url", dest="terraform_url", default="terraform.corp.clover.com")
-    p.add_option("--type",dest="resource_type")
-    p.add_option("--attr", action="append")
-    p.add_option("--output", default=os.path.join(os.path.dirname(__file__), "reports/resources"))
-    opt, args = p.parse_args()
-    data = main(opt.terraform_org, opt.terraform_url, opt.resource_type, opt.attr)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org", dest="terraform_org", default="clover")
+    parser.add_argument("--url", dest="terraform_url", default="terraform.corp.clover.com")
+    parser.add_argument("--type",dest="resource_type")
+    parser.add_argument("--attr", action="append")
+    parser.add_argument("--output", default=os.path.join(os.path.dirname(__file__), "reports/resources"))
+    args = parser.parse_args()
+    data = main(args.terraform_org, args.terraform_url, args.resource_type, args.attr)
     workspace_dict = defaultdict(lambda: defaultdict(list))
     for k, v in data.items():
         for resource in v:
@@ -50,7 +50,7 @@ if __name__ == '__main__':
                 if resource.get(attr) not in workspace_dict[k][attr]:
                     workspace_dict[k][attr].append(resource.get(attr))
     
-    with open(os.path.join(opt.output, f"{opt.resource_type}.json"), 'w') as output:
+    with open(os.path.join(args.output, f"{args.resource_type}.json"), 'w') as output:
         output.write(
             json.dumps(
                 workspace_dict,

--- a/gtag
+++ b/gtag
@@ -2,6 +2,7 @@
 import semantic_version
 import subprocess
 import os
+import argparse
 
 def main(message, major, minor, patch):
     os.chdir(os.getcwd())
@@ -46,11 +47,10 @@ def main(message, major, minor, patch):
     out, _ = p.communicate()
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-m", dest="message")
-    p.add_option("--patch", dest="patch", default=True, action="store_true")
-    p.add_option("--minor", dest="minor", default=False, action="store_true")
-    p.add_option("--major", dest="major", default=False, action="store_true")
-    opt, args = p.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", dest="message")
+    parser.add_argument("--patch", dest="patch", default=True, action="store_true")
+    parser.add_argument("--minor", dest="minor", default=False, action="store_true")
+    parser.add_argument("--major", dest="major", default=False, action="store_true")
+    opt, args = parser.parse_args()
     main(opt.message, opt.major, opt.minor, opt.patch)

--- a/mod_versions
+++ b/mod_versions
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import argparse
 
 repo_template = "git@github.corp.clover.com:clover/terraform-{mod_provider}-{mod_name}.git"
 
@@ -41,18 +42,15 @@ def main(key, source):
     return mods
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    for cli_param in ["key", "source"]:
-        p.add_option(f"--{cli_param}", default=False)
-    opt, arg = p.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--key", default=False)
+    parser.add_argument("--source", default=False)
+    args = parser.parse_args()
     print(
         json.dumps(
-            main(opt.key, opt.source),
+            main(args.key, args.source),
             separators=(',', ':'),
             indent=4,
             sort_keys=True
         )
     )
-        
-

--- a/modtest
+++ b/modtest
@@ -54,13 +54,12 @@ if __name__ == '__main__':
 
     the key would be binlookupservice.
     ''')
-    from optparse import OptionParser
-    p = OptionParser(usage=doc.render(file_name=os.path.basename(__file__)))
-    for cli_param in ["key", "branch"]:
-        p.add_option(f"--{cli_param}", default=False)
-    for cli_param in ["target", "refresh", "plan"]:
-        p.add_option(f"--{cli_param}", action="store_true", default=False)
-    opt, arg = p.parse_args()
-    main(opt.key, opt.branch, opt.refresh, opt.target, opt.plan),
-    
-
+    import argparse
+    parser = argparse.ArgumentParser(usage=doc.render(file_name=os.path.basename(__file__)))
+    parser.add_argument("--key", default=False)
+    parser.add_argument("--branch", default=False)
+    parser.add_argument("--target", action="store_true", default=False)
+    parser.add_argument("--refresh", action="store_true", default=False)
+    parser.add_argument("--plan", action="store_true", default=False)
+    opt = parser.parse_args()
+    main(opt.key, opt.branch, opt.refresh, opt.target, opt.plan)

--- a/non_applied.py
+++ b/non_applied.py
@@ -58,13 +58,13 @@ def main(terraform_url, terraform_org):
     
 
 if __name__ == "__main__":
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-t", dest="terraform_url", default="terraform.corp.clover.com")
-    p.add_option("-o", dest="terraform_org", default="clover")
-    opt, arg = p.parse_args()
-    main(opt.terraform_url, opt.terraform_org)
-    for ws in main(opt.terraform_url, opt.terraform_org):
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", dest="terraform_url", default="terraform.corp.clover.com")
+    parser.add_argument("-o", dest="terraform_org", default="clover")
+    args = parser.parse_args()
+    main(args.terraform_url, args.terraform_org)
+    for ws in main(args.terraform_url, args.terraform_org):
         print(
             "\nWorkspace: {0}".format(ws[0]),
             "\n\tPlanned: {0}".format(ws[1]),

--- a/nonmanaged_workspaces.py
+++ b/nonmanaged_workspaces.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode, quote_plus
 from pathlib import Path
 import helpers
 import re
+import argparse
 
 def sanitize_path(config):
     path = os.path.expanduser(config)
@@ -78,12 +79,10 @@ def main(terraform_url, terraform_org, output, workspace_name=False):
 
 
 if __name__ == "__main__":
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-t", dest="terraform_url", default="terraform.corp.clover.com")
-    p.add_option("--org", dest="terraform_org", default="clover")
-    p.add_option("-o", dest='output', default=os.path.join(os.path.dirname(__file__), "./reports/nonmanaged-workspaces.json"))
-    p.add_option("-w", dest="workspace", default=None)
-    opt, arg = p.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", dest="terraform_url", default="terraform.corp.clover.com")
+    parser.add_argument("--org", dest="terraform_org", default="clover")
+    parser.add_argument("-o", dest='output', default=os.path.join(os.path.dirname(__file__), "./reports/nonmanaged-workspaces.json"))
+    parser.add_argument("-w", dest="workspace", default=None)
+    opt = parser.parse_args()
     main(opt.terraform_url, opt.terraform_org, opt.output, opt.workspace)
-    

--- a/rsc_count.py
+++ b/rsc_count.py
@@ -71,11 +71,10 @@ def main(terraform_url, terraform_org, workspace_name):
     )
 
 if __name__ == "__main__":
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-t", dest="terraform_url", default="terraform.corp.clover.com")
-    p.add_option("--org", dest="terraform_org", default="clover")
-    p.add_option("-w", dest="workspace_name")
-    opt, arg = p.parse_args()
-    main(opt.terraform_url, opt.terraform_org, opt.workspace_name)
-    
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", dest="terraform_url", default="terraform.corp.clover.com")
+    parser.add_argument("--org", dest="terraform_org", default="clover")
+    parser.add_argument("-w", dest="workspace_name")
+    args = parser.parse_args()
+    main(args.terraform_url, args.terraform_org, args.workspace_name)

--- a/shared_repos.py
+++ b/shared_repos.py
@@ -74,13 +74,12 @@ def main(terraform_url, terraform_org, github_base, basedir, git_namespace):
         )
 
 if __name__ == "__main__":
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("-t", dest="terraform_url", default="terraform.corp.clover.com")
-    p.add_option("-o", dest="terraform_org", default="clover")
-    p.add_option("-g", dest="github_base",   default="https://github.corp.clover.com")
-    p.add_option("-n", dest="git_namespace", default="clover")
-    p.add_option("-b", dest='base_dir',      default=mkdtemp(prefix="/tmp/"))
-    opt, arg = p.parse_args()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", dest="terraform_url", default="terraform.corp.clover.com")
+    parser.add_argument("-o", dest="terraform_org", default="clover")
+    parser.add_argument("-g", dest="github_base",   default="https://github.corp.clover.com")
+    parser.add_argument("-n", dest="git_namespace", default="clover")
+    parser.add_argument("-b", dest='base_dir',      default=mkdtemp(prefix="/tmp/"))
+    opt, arg = parser.parse_args()
     main(opt.terraform_url, opt.terraform_org, opt.github_base, opt.base_dir, opt.git_namespace)
-    

--- a/terratest-cleanup.py
+++ b/terratest-cleanup.py
@@ -58,12 +58,12 @@ def main(bucket_name, base_dir, github_base, git_org, module):
     # )
 
 if __name__ == '__main__':
-    from optparse import OptionParser
-    p = OptionParser()
-    p.add_option("--bucket", default="clover-terratest-state")
-    p.add_option("-b", dest='base_dir', default=os.path.join(os.getcwd(), "terratest_statefiles"))
-    p.add_option("-g", default="https://github.corp.clover.com", dest="github_base")
-    p.add_option("-o", default="clover", dest="git_org")
-    p.add_option("--module")
-    opt, args = p.parse_args()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bucket", default="clover-terratest-state")
+    parser.add_argument("-b", dest='base_dir', default=os.path.join(os.getcwd(), "terratest_statefiles"))
+    parser.add_argument("-g", default="https://github.corp.clover.com", dest="github_base")
+    parser.add_argument("-o", default="clover", dest="git_org")
+    parser.add_argument("--module")
+    opt = parser.parse_args()
     main(opt.bucket, opt.base_dir, opt.github_base, opt.git_org, opt.module)


### PR DESCRIPTION
Replace `optparse` with `argparse` for command-line option parsing in multiple files.

* **all_locations.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **check_latest.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **checks/vault_access.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **envcmp.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **find_rsc_attrs_in_workspaces.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **gtag**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **mod_versions**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **modtest**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **non_applied.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **nonmanaged_workspaces.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **rsc_count.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **shared_repos.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

* **terratest-cleanup.py**
  - Replace `optparse` with `argparse` for command-line option parsing.
  - Update the `if __name__ == '__main__':` block to use `argparse`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HappyPathway/tfe-tools/pull/4?shareId=50da986e-962e-4d9e-999d-b45737a617f7).