### PR TITLE
Add unit tests for common functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pygit2==1.10.0
 google-cloud-storage
 PyGithub==1.55
 python-terraform==0.10.1
+pytest

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,44 @@
+import os
+import json
+import pytest
+from unittest.mock import patch, mock_open
+from tfe_tools.common import sanitize_path, tfe_token, get_requests_session, mod_dependencies, find_mod_source
+
+def test_sanitize_path():
+    assert sanitize_path("~/test") == os.path.abspath(os.path.expanduser("~/test"))
+    assert sanitize_path("$HOME/test") == os.path.abspath(os.path.expandvars("$HOME/test"))
+    assert sanitize_path("/test") == os.path.abspath("/test")
+
+@patch("builtins.open", new_callable=mock_open, read_data='{"credentials": [{"terraform.corp.clover.com": {"token": "test_token"}}]}')
+@patch("os.path.isfile", return_value=True)
+def test_tfe_token(mock_isfile, mock_open):
+    assert tfe_token("terraform.corp.clover.com", "~/test") == "test_token"
+
+@patch("tfe_tools.common.sanitize_path", return_value="/test")
+@patch("builtins.open", new_callable=mock_open, read_data='{"credentials": {"terraform.corp.clover.com": {"token": "test_token"}}}')
+@patch("os.path.isfile", return_value=True)
+def test_tfe_token_with_sanitize_path(mock_isfile, mock_open, mock_sanitize_path):
+    assert tfe_token("terraform.corp.clover.com", "~/test") == "test_token"
+
+@patch("tfe_tools.common.sanitize_path", return_value="/test")
+@patch("builtins.open", new_callable=mock_open, read_data='{"credentials": {"terraform.corp.clover.com": {"token": "test_token"}}}')
+@patch("os.path.isfile", return_value=False)
+@patch("os.environ.get", return_value="test_token")
+def test_tfe_token_with_env_var(mock_get, mock_isfile, mock_open, mock_sanitize_path):
+    assert tfe_token("terraform.corp.clover.com", "~/test") == "test_token"
+
+@patch("tfe_tools.common.tfe_token", return_value="test_token")
+def test_get_requests_session(mock_tfe_token):
+    session = get_requests_session()
+    assert session.headers["Authorization"] == "Bearer test_token"
+    assert session.headers["Content-Type"] == "application/vnd.api+json"
+
+@patch("glob.glob", return_value=["test.tf"])
+@patch("builtins.open", new_callable=mock_open, read_data='{"module": {"test_module": {"source": "test_source"}}}')
+def test_mod_dependencies(mock_open, mock_glob):
+    assert mod_dependencies("test_module") == {"test_module": "test_source"}
+
+@patch("subprocess.Popen")
+def test_find_mod_source(mock_popen):
+    mock_popen.return_value.communicate.return_value = (json.dumps({"test": "test"}).encode("utf-8"), b"")
+    assert find_mod_source("test_source") == {"test": "test"}


### PR DESCRIPTION
Add unit tests for common functions in `tfe_tools/common.py`.

* **tests/test_common.py**
  - Add unit tests for `sanitize_path` function.
  - Add unit tests for `tfe_token` function with different scenarios.
  - Add unit tests for `get_requests_session` function.
  - Add unit tests for `mod_dependencies` function.
  - Add unit tests for `find_mod_source` function.

* **requirements.txt**
  - Add `pytest` to the list of dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HappyPathway/tfe-tools/pull/5?shareId=4abd953b-6393-4e6f-8c03-e4b713618a63).