### PR TITLE
Add GitHub Actions workflow to run Python tests

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,32 @@
+name: Python Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run tests
+      run: |
+        pytest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # tfe-tools
 Tools for interacting with TFE Api
+
+## GitHub Actions Workflow for Running Python Tests
+
+This repository includes a GitHub Actions workflow to run Python tests. The workflow is triggered on the following events:
+- `push`
+- `workflow_dispatch`
+- `pull_request`
+
+The workflow sets up a Python environment, installs dependencies from `requirements.txt`, and runs the tests using `pytest`.
+
+### Manually Triggering the Workflow
+
+To manually trigger the workflow, follow these steps:
+1. Go to the "Actions" tab in your GitHub repository.
+2. Select the "Python Tests" workflow from the list of workflows.
+3. Click on the "Run workflow" button.
+4. Choose the branch on which you want to run the workflow.
+5. Click on the "Run workflow" button to start the workflow.


### PR DESCRIPTION
Add a GitHub Actions workflow to run Python tests on push, manual trigger, and pull requests.

* **README.md**
  - Add a section to describe the new GitHub Actions workflow for running Python tests.
  - Include instructions on how to trigger the workflow manually.

* **.github/workflows/python-tests.yaml**
  - Create a new GitHub Actions workflow file.
  - Trigger the workflow on `push`, `workflow_dispatch`, and `pull_request` events.
  - Set up a Python environment using `actions/setup-python@v2`.
  - Install dependencies from `requirements.txt`.
  - Run the tests using `pytest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HappyPathway/tfe-tools/pull/6?shareId=c438c41a-142e-4a74-be75-5ea2b5bf4c53).