### PR TITLE
Fix imports in test_common.py

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@ import os
 import json
 import pytest
 from unittest.mock import patch, mock_open
-from tfe_tools.common import sanitize_path, tfe_token, get_requests_session, mod_dependencies, find_mod_source
+from tfe_tools.common import sanitize_path, tfe_token, get_requests_session, mod_dependencies, find_mod_source, TFEException, query_match, get_attr, filter_type
 
 def test_sanitize_path():
     assert sanitize_path("~/test") == os.path.abspath(os.path.expanduser("~/test"))

--- a/tfe_tools/common.py
+++ b/tfe_tools/common.py
@@ -8,6 +8,11 @@ import hcl2
 from glob import glob
 from requests import Session
 
+class TFEException(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+        super().__init__(msg)
+
 def sanitize_path(config):
     path = os.path.expanduser(config)
     path = os.path.expandvars(path)
@@ -133,6 +138,19 @@ def find_interesting_records(key, value, resource_type, workspaces=[], base_dir=
                 )
                 interest[data.get("repo")]['addresses'].append(rsc.get('tf_address'))
     return results, [interest.get(repo_name) for repo_name in interest if interest.get(repo_name).get('addresses')]
+
+def query_match(rsc, key, value, resource_type):
+    if rsc.get('resource_type') != resource_type:
+        return False
+    if rsc.get(key) != value:
+        return False
+    return True
+
+def get_attr(instance, attr):
+    return getattr(instance, attr, None)
+
+def filter_type(instances, instance_type):
+    return [instance for instance in instances if isinstance(instance, instance_type)]
 
 def main(source, dump_modules, dump_workspaces):
     # terraform.corp.clover.com/clover/datacenter_infra/google 


### PR DESCRIPTION
Fix broken Python testing by correcting imports and adding missing functions.

* **tfe_tools/common.py**
  - Add `TFEException` class to handle exceptions.
  - Add `query_match` function to match query parameters.
  - Add `get_attr` function to get attributes from instances.
  - Add `filter_type` function to filter instances by type.

* **tests/test_common.py**
  - Add imports for `TFEException`, `query_match`, `get_attr`, and `filter_type` from `tfe_tools.common`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HappyPathway/tfe-tools?shareId=XXXX-XXXX-XXXX-XXXX).